### PR TITLE
feat(auth): implement change password functionality for users

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -40,4 +40,35 @@ class AuthController extends Controller
         $request->session()->regenerateToken();
         return redirect('/login');
     }
+
+    public function showChangePasswordForm()
+    {
+        return view('change_password');
+    }
+
+    public function changePassword(Request $request)
+    {
+        $request->validate([
+            'current_password' => 'required',
+            'new_password' => 'required|min:8|confirmed',
+        ]);
+
+        $user = Auth::user();
+
+        if (!\Hash::check($request->current_password, $user->password)) {
+            return back()->withErrors(['current_password' => 'Current password is incorrect.']);
+        }
+
+        if ($request->current_password === $request->new_password) {
+            return back()->withErrors(['new_password' => 'New password must be different from the current password.']);
+        }
+
+        $user->password = bcrypt($request->new_password);
+        $user->save();
+
+        // Optionally log out other sessions
+        // Auth::logoutOtherDevices($request->new_password);
+
+        return back()->with('status', 'Password changed successfully!');
+    }
 }

--- a/resources/views/change_password.blade.php
+++ b/resources/views/change_password.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.base')
+
+@section('styles')
+    <link rel="stylesheet" href="{{ asset('css/dashboard.css') }}">
+@endsection
+
+@section('title', 'Change Password')
+
+@section('content')
+<div class="page d-flex">
+    @include('partials.sidebar')
+    <div class="content flex-1">
+        @include('partials.header')
+        <h1 class="content-title">Change Password</h1>
+        <div class="section-content p-15 d-flex gap-20 column-mobile">
+            <div class="account-settings bg-white p-15 rad-6" style="min-width:350px;max-width:400px;margin:auto;">
+                <h2 class="m-15-0">Update Your Password</h2>
+                @if (session('status'))
+                    <div class="alert alert-success">{{ session('status') }}</div>
+                @endif
+                @if ($errors->any())
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+                <form method="POST" action="{{ route('password.change') }}">
+                    @csrf
+                    <div class="setting-row mb-15">
+                        <label for="current_password" class="fw-bold">Current Password</label>
+                        <input type="password" name="current_password" id="current_password" class="form-control" required>
+                    </div>
+                    <div class="setting-row mb-15">
+                        <label for="new_password" class="fw-bold">New Password</label>
+                        <input type="password" name="new_password" id="new_password" class="form-control" required>
+                    </div>
+                    <div class="setting-row mb-20">
+                        <label for="new_password_confirmation" class="fw-bold">Confirm New Password</label>
+                        <input type="password" name="new_password_confirmation" id="new_password_confirmation" class="form-control" required>
+                    </div>
+                    <button type="submit" class="bg-blue pointer btn-primary w-100">Change Password</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection 

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -67,7 +67,7 @@
                     <div class="setting-row d-flex align-c gap-10">
                         <label class="setting-label fw-bold flex-1" for="password">Password</label>
                         <input type="password" id="password" class="form-control flex-3 me-20" value="********" disabled>
-                        <button type="button" class="bg-blue pointer btn-primary flex-1">Change Password</button>
+                        <button type="button" class="bg-blue pointer btn-primary flex-1" onclick="window.location.href='{{ route('password.change.form') }}'">Change Password</button>
                     </div>
                 </form>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,10 @@ Route::middleware('auth')->group(function () {
         return view('profile');
     });
 
+    // Change Password Routes
+    Route::get('/change-password', [AuthController::class, 'showChangePasswordForm'])->name('password.change.form');
+    Route::post('/change-password', [AuthController::class, 'changePassword'])->name('password.change');
+
     // User Routes
 
     Route::get('/my-budget', UserBudgetController::class . "@loadUserBudget")


### PR DESCRIPTION
## Feature: Change Password Functionality

#### Overview
Implements a secure "Change Password" feature that allows authenticated users to update their password from within their account settings.

## Details
- Added routes for displaying and handling the change password form (protected by auth middleware).
- Added methods to `AuthController` for showing the form and processing the password update.
- Created a new Blade view for the change password form with fields for current password, new password, and confirmation.
- Updated the profile page to link to the change password form.
- Implemented validation for current password, new password requirements, and confirmation match.
- Provided user feedback via flash messages for both success and errors.
- (Optional) Code included to log out other devices after password change (currently commented out).

## Acceptance Criteria
- Only authenticated users can access the change password form.
- Form includes all required fields.
- Proper validation and error handling.
- User receives feedback after attempting to change password.

## Security
- Passwords are hashed before saving.
- Validation ensures strong passwords and prevents reuse of the current password.

---

Closes #7